### PR TITLE
DBのカラム名が"USER_NAME"のように大文字だとResultSetWrapper#underscoreSeparatedStrin…

### DIFF
--- a/src/main/kotlin/net/devneko/kjdbc/ResultSetWrapper.kt
+++ b/src/main/kotlin/net/devneko/kjdbc/ResultSetWrapper.kt
@@ -187,7 +187,7 @@ class ResultSetWrapper(
     }
 
     fun underscoreSeparatedStringToCamelCase(str:String):String {
-        return Regex("_([a-z])").replace(str, { r ->
+        return Regex("_([a-z])").replace(str.toLowerCase(), { r ->
             val g = r.groups[1]
             g?.value?.capitalize() ?: ""
         })


### PR DESCRIPTION
…gToCamelCase()でキャメルケースに変換できない問題の対応

If the DB column name is uppercase like "USER_NAME", it can't be converted to Camel case in ResultSetWrapper#underscoreSeparatedStringToCamelCase()